### PR TITLE
Update `configure_me_codegen`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "configure_me_codegen"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ddbd860cbff075ceadf4714922a73afbe8bf53d9ed9add6c6b733feeb6f3c7"
+checksum = "981fb98983781be95b91dc4ce7c178ae000f91350d783d43d1ce8adc4963c91f"
 dependencies = [
  "cargo_toml",
  "fmt2io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,4 @@ ln-types = { version = "0.1.2", features = ["serde", "parse_arg"] }
 configure_me = "0.4.0"
 
 [build-dependencies]
-configure_me_codegen = "0.4.1"
+configure_me_codegen = "0.4.3"

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,3 @@
-fn main() -> Result<(), configure_me_codegen::Error> {
-    configure_me_codegen::build_script_auto()
+fn main() {
+    configure_me_codegen::build_script_auto().unwrap_or_else(|error| error.report_and_exit());
 }


### PR DESCRIPTION
The new version improves developer error reporting and reduces warnings in the generated code.

Cc @DanGould you may want to import this change into your fork. build/test/check with `--features=configure_me_codegen/spanned` during development to get nice error messages in case of malformed configuration specification.